### PR TITLE
Shunt out the IP to countrycode detection.

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -10,6 +10,7 @@
 
 yourls_add_filter( 'get_IP', 'wlabarron_anonymise_IP' );
 yourls_add_filter( 'get_user_agent', 'wlabarron_anonymise_user_agent' );
+yourls_add_filter( 'shunt_geo_ip_to_countrycode', 'wlabarron_shunt_country' );
 
 function wlabarron_anonymise_IP( $ip ) {
     return "-";
@@ -17,6 +18,10 @@ function wlabarron_anonymise_IP( $ip ) {
 
 function wlabarron_anonymise_user_agent( $ua ) {
     return "-";
+}
+
+function wlabarron_shunt_country( $location = false, $ip = '', $default = '' ) {
+    return "";
 }
 
 ?>


### PR DESCRIPTION
Since the IP is not resolveable to a country code anyways, the complete detection can be shunted out. 