### PR TITLE
Return an empty string instead of a hyphen as IP address

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -12,7 +12,7 @@ yourls_add_filter( 'get_IP', 'wlabarron_anonymise_IP' );
 yourls_add_filter( 'get_user_agent', 'wlabarron_anonymise_user_agent' );
 
 function wlabarron_anonymise_IP( $ip ) {
-    return "-";
+    return "";
 }
 
 function wlabarron_anonymise_user_agent( $ua ) {


### PR DESCRIPTION
The default value for the IP address in the yourls code is usually an empty string, not an hyphen.
[Example 1](https://github.com/YOURLS/YOURLS/blob/235d639799ae993f3655c4af156f7b16f7e86782/includes/functions.php#L946-L948) [Example 2](https://github.com/YOURLS/YOURLS/blob/235d639799ae993f3655c4af156f7b16f7e86782/includes/functions.php#L84)
The hyphen would even get removed when sanitized in the [yourls_sanitize_ip()](https://github.com/YOURLS/YOURLS/blob/235d639799ae993f3655c4af156f7b16f7e86782/includes/functions-formatting.php#L160) function.